### PR TITLE
Fix for railtie mis-spellings

### DIFF
--- a/lib/acts_as_markup/railtie.rb
+++ b/lib/acts_as_markup/railtie.rb
@@ -4,8 +4,8 @@ module ActsAsMarkup
     
     initializer 'acts_as_markup.set_config', :after => 'active_record.initialize_database' do |app|
       ActiveSupport.on_load(:acts_as_markup) do
-        self.markdown_library = app.config.acts_as_makrup.markdown_library
-        self.mediawiki_library = app.config.acts_as_makrup.mediawiki_library
+        self.markdown_library = app.config.acts_as_markup.markdown_library
+        self.mediawiki_library = app.config.acts_as_markup.mediawiki_library
       end
     end
     
@@ -14,13 +14,13 @@ module ActsAsMarkup
         require 'acts_as_markup/exts/object'
         require 'acts_as_markup/stringlike'
         require 'acts_as_markup/active_record_extension'
-        self.send :include, ActsAsMakup::ActiveRecordExtension
+        self.send :include, ActsAsMarkup::ActiveRecordExtension
       end
     end
     
     config.before_configuration do
-      config.acts_as_makrup.markdown_library = :rdiscount
-      config.acts_as_makrup.mediawiki_library = :wikicloth
+      config.acts_as_markup.markdown_library = :rdiscount
+      config.acts_as_markup.mediawiki_library = :wikicloth
     end
   end
 end


### PR DESCRIPTION
There were a number of mis-spellings in the railtie causing method
missing and undefined constant errors
